### PR TITLE
Fix converter import path

### DIFF
--- a/src/utils/converter.py
+++ b/src/utils/converter.py
@@ -2,15 +2,13 @@ import os
 import sys
 from pathlib import Path
 
-from src.utils.files import get_capture_date, get_video_capture_date
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.utils.files import get_capture_date, get_video_capture_date
 
 import datetime
 import logging
 import subprocess
-import sys
-from pathlib import Path
 
 import httpx
 from PIL import Image


### PR DESCRIPTION
## Summary
- fix `src` imports on Linux by inserting parent path before importing

## Testing
- `python3 -m py_compile main.py run.py src/**/*.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_685313ab8300832690f679d9a16c6642